### PR TITLE
Support work folders, improve agent info scraping

### DIFF
--- a/VSTSAgent/DSCResources/xVSTSAgent/xVSTSAgent.schema.mof
+++ b/VSTSAgent/DSCResources/xVSTSAgent/xVSTSAgent.schema.mof
@@ -5,9 +5,10 @@ class xVSTSAgent : OMI_BaseResource
     [Key] String Name;
     [Write] String Pool;
     [Required, EmbeddedInstance("MSFT_Credential")] String AccountCredential;
-    [Required] String Account;
+    [Required] String ServerUrl;
     [Write, EmbeddedInstance("MSFT_Credential")] String LogonCredential;
     [Required] String AgentDirectory;
+    [Write] String Work;
     [Write] Boolean PrefixComputerName;
     [Write, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/VSTSAgent/Examples/Sample_xVSTSAgent.ps1
+++ b/VSTSAgent/Examples/Sample_xVSTSAgent.ps1
@@ -8,7 +8,7 @@ Configuration Sample_xVSTSAgent {
     (   
         [parameter(Mandatory = $true)] 
         [System.String]
-        $Account,
+        $ServerUrl,
 
         [System.String]
         $Name = "$env:COMPUTERNAME",
@@ -26,6 +26,9 @@ Configuration Sample_xVSTSAgent {
         [System.String]
         $AgentDirectory = 'C:\VSTSAgents',
 
+        [System.String]
+        $Work,
+
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
@@ -34,17 +37,18 @@ Configuration Sample_xVSTSAgent {
         $PrefixComputerName = $false
     )
 
-    Import-DscResource -ModuleName VSTSAgent
+    Import-DscResource -ModuleName VSTSAgent -ModuleVersion '2.0'
 
     Node 'localhost' {
 
         xVSTSAgent VSTSAgent {
             Name               = $Name
             Pool               = $Pool
-            Account            = $Account
+            ServerUrl          = $ServerUrl
             AccountCredential  = $AccountCredential
             LogonCredential    = $LogonCredential
             AgentDirectory     = $AgentDirectory
+            Work               = $Work
             Ensure             = $Ensure
             PrefixComputerName = $PrefixComputerName
         }

--- a/VSTSAgent/VSTSAgent.psd1
+++ b/VSTSAgent/VSTSAgent.psd1
@@ -11,28 +11,28 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule        = 'VSTSAgent.psm1'
+    RootModule           = 'VSTSAgent.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1'
+    ModuleVersion        = '2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
 
     # ID used to uniquely identify this module
-    GUID              = '679b6302-ff19-4e53-a20f-eac2f531b5b6'
+    GUID                 = '679b6302-ff19-4e53-a20f-eac2f531b5b6'
 
     # Author of this module
-    Author            = 'Microsoft'
+    Author               = 'Microsoft'
 
     # Company or vendor of this module
-    CompanyName       = 'Microsoft'
+    CompanyName          = 'Microsoft'
 
     # Copyright statement for this module
-    Copyright         = 'Copyright (c) Microsoft Corporation. All rights reserved.'
+    Copyright            = 'Copyright (c) Microsoft Corporation. All rights reserved.'
 
     # Description of the functionality provided by this module
-    Description       = 'Tools for managing and automating your VSTS Agents.'
+    Description          = 'Tools for managing and automating your VSTS Agents.'
 
     # Minimum version of the Windows PowerShell engine required by this module
     # PowerShellVersion = ''
@@ -71,7 +71,7 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @(
+    FunctionsToExport    = @(
         'Find-VSTSAgent', 
         'Install-VSTSAgent', 
         'Get-VSTSAgent', 
@@ -81,16 +81,16 @@
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-    CmdletsToExport   = @()
+    CmdletsToExport      = @()
 
     # Variables to export from this module
-    VariablesToExport = @()
+    VariablesToExport    = @()
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport   = @()
+    AliasesToExport      = @()
 
     # DSC resources to export from this module
-    # DscResourcesToExport = @()
+    DscResourcesToExport = @('xVSTSAgent')
 
     # List of all modules packaged with this module
     # ModuleList = @()
@@ -99,7 +99,7 @@
     # FileList = @()
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-    PrivateData       = @{
+    PrivateData          = @{
 
         PSData = @{
 
@@ -123,7 +123,7 @@
     } # End of PrivateData hashtable
 
     # HelpInfo URI of this module
-    HelpInfoURI       = 'https://github.com/Microsoft/VSTSAgent.PowerShell/blob/master/README.md'
+    HelpInfoURI          = 'https://github.com/Microsoft/VSTSAgent.PowerShell/blob/master/README.md'
 
     # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
     # DefaultCommandPrefix = ''


### PR DESCRIPTION
This allows specifying a directory where the agent should perform it's work separate from where it is installed.

To test and compare the work folder I had to crack the .agent metadata file. To ease comparisons I've moved to a `ServerUrl` and not an `Account` value. This is more flexible and matches the underlying tooling better as well.

Found that the .service metadata sits alongside .agent and I now use that to find the service by name instead of assuming a convention.

Added implementation for uninstalling the agent when 'Absent' is specified.

Resolves #11 