### PR TITLE
Change PrefixComputerName parameter type

### DIFF
--- a/VSTSAgent/Examples/Sample_xVSTSAgent.ps1
+++ b/VSTSAgent/Examples/Sample_xVSTSAgent.ps1
@@ -33,8 +33,8 @@ Configuration Sample_xVSTSAgent {
         [System.String]
         $Ensure = 'Present',
 
-        [System.Boolean]
-        $PrefixComputerName = $false
+        [Switch]
+        $PrefixComputerName
     )
 
     Import-DscResource -ModuleName VSTSAgent


### PR DESCRIPTION
Changed PrefixComputerName from a boolean (with a default value of false) to a switch type of parameter (inherently false by default as well). This change follows practices that are recommended by the community and PowerShell team. Happy #hacktoberfest!