### PR TITLE
Add quotes to install args

### DIFF
--- a/VSTSAgent/VSTSAgent.psm1
+++ b/VSTSAgent/VSTSAgent.psm1
@@ -310,8 +310,10 @@ function Install-VSTSAgent {
     $outFile = [io.path]::Combine($agentFolder, "out.log")
     $errorFile = [io.path]::Combine($agentFolder, "error.log")
 
+    $quotedConfigArgs = $configArgs | ForEach-Object -Process "`"$_`"" 
+
     Write-Verbose "Registering $Name to $Pool at $ServerUrl"
-    Start-Process $configPath -ArgumentList $configArgs -NoNewWindow -Wait `
+    Start-Process $configPath -ArgumentList $quotedConfigArgs -NoNewWindow -Wait `
         -RedirectStandardOutput $outFile -RedirectStandardError $errorFile -ErrorAction Stop
 
     if (Test-Path $errorFile) {


### PR DESCRIPTION
This PR adds quotes to all installation arguments passed to `Start-Process`. The intent is to ensure all current and future arguments are quoted without the need to quote them individually.