### PR TITLE
Support for installation of agent as an environment virtual machine resource

### DIFF
--- a/VSTSAgent/DSCResources/xVSTSAgent/xVSTSAgent.psm1
+++ b/VSTSAgent/DSCResources/xVSTSAgent/xVSTSAgent.psm1
@@ -115,6 +115,12 @@ function Set-TargetResource {
         $DeploymentGroupTags = '',
 
         [System.String]
+        $Environment = '',
+
+        [System.String]
+        $VirtualMachineResourceTags = '',
+
+        [System.String]
         [string]$ProjectName = '',
 
         [parameter(Mandatory = $true)]
@@ -150,15 +156,17 @@ function Set-TargetResource {
 
     if ( $Ensure -eq 'Present') {
         $installArgs = @{
-            'Name'                  = $Name 
-            'Pool'                  = $Pool
-            'ServerUrl'             = $ServerUrl
-            'PAT'                   = $AccountCredential.Password
-            'AgentDirectory'        = $AgentDirectory
-            'Replace'               = $true
-            'DeploymentGroup'       = $DeploymentGroup
-            'DeploymentGroupTags'   = $DeploymentGroupTags
-            'ProjectName'           = $ProjectName
+            'Name'                       = $Name 
+            'Pool'                       = $Pool
+            'ServerUrl'                  = $ServerUrl
+            'PAT'                        = $AccountCredential.Password
+            'AgentDirectory'             = $AgentDirectory
+            'Replace'                    = $true
+            'DeploymentGroup'            = $DeploymentGroup
+            'DeploymentGroupTags'        = $DeploymentGroupTags
+            'Environment'                = $Environment
+            'VirtualMachineResourceTags' = $VirtualMachineResourceTags
+            'ProjectName'                = $ProjectName
         }
 
         if ( $Work ) { $installArgs['Work'] = $Work }
@@ -206,6 +214,12 @@ function Test-TargetResource {
 
         [System.String]
         $DeploymentGroupTags = '',
+
+        [System.String]
+        $Environment = '',
+
+        [System.String]
+        $VirtualMachineResourceTags = '',
 
         [System.String]
         [string]$ProjectName = '',

--- a/VSTSAgent/DSCResources/xVSTSAgent/xVSTSAgent.schema.mof
+++ b/VSTSAgent/DSCResources/xVSTSAgent/xVSTSAgent.schema.mof
@@ -7,6 +7,8 @@ class xVSTSAgent : OMI_BaseResource
     [Write] String ProjectName;
     [Write] String DeploymentGroup;
     [Write] String DeploymentGroupTags;
+    [Write] String Environment;
+    [Write] String VirtualMachineResourceTags;
     [Required, EmbeddedInstance("MSFT_Credential")] String AccountCredential;
     [Required] String ServerUrl;
     [Write, EmbeddedInstance("MSFT_Credential")] String LogonCredential;

--- a/VSTSAgent/VSTSAgent.psm1
+++ b/VSTSAgent/VSTSAgent.psm1
@@ -309,13 +309,13 @@ function Install-VSTSAgent {
     [string[]]$configArgs = @('--unattended', '--url', "$ServerUrl", '--auth', `
             'pat', '--agent', "$Name", '--runAsService')
 
-	if ($Pool) { $configArgs += '--pool', $Pool }
+    if ($Pool) { $configArgs += '--pool', $Pool }
 
-	if ($DeploymentGroup) { $configArgs += '--deploymentgroup', '--deploymentgroupname', $DeploymentGroup }
-	if ($DeploymentGroupTags) { $configArgs += '--addDeploymentGroupTags', '--deploymentGroupTags', $DeploymentGroupTags }
+    if ($DeploymentGroup) { $configArgs += '--deploymentgroup', '--deploymentgroupname', $DeploymentGroup }
+    if ($DeploymentGroupTags) { $configArgs += '--addDeploymentGroupTags', '--deploymentGroupTags', $DeploymentGroupTags }
     if ($Environment) { $configArgs += '--environment', '--environmentName', $Environment }
     if ($VirtualMachineResourceTags) { $configArgs += '--addvirtualmachineresourcetags', '--virtualmachineresourcetags', $VirtualMachineResourceTags }
-	if ($ProjectName) { $configArgs += '--projectname', $ProjectName }
+    if ($ProjectName) { $configArgs += '--projectname', $ProjectName }
 
     if ( $Replace ) { $configArgs += '--replace' }
     if ( $LogonCredential ) { $configArgs += '--windowsLogonAccount', $LogonCredential.UserName }

--- a/VSTSAgent/VSTSAgent.psm1
+++ b/VSTSAgent/VSTSAgent.psm1
@@ -229,6 +229,12 @@ function Install-VSTSAgent {
         [string]$DeploymentGroupTags = '',
 
         [parameter(Mandatory = $false)]
+        [string]$Environment = '',
+
+        [parameter(Mandatory = $false)]
+        [string]$VirtualMachineResourceTags = '',
+
+        [parameter(Mandatory = $false)]
         [string]$ProjectName = '',
 
         [parameter(Mandatory = $true)]
@@ -307,6 +313,8 @@ function Install-VSTSAgent {
 
 	if ($DeploymentGroup) { $configArgs += '--deploymentgroup', '--deploymentgroupname', $DeploymentGroup }
 	if ($DeploymentGroupTags) { $configArgs += '--addDeploymentGroupTags', '--deploymentGroupTags', $DeploymentGroupTags }
+    if ($Environment) { $configArgs += '--environment', '--environmentName', $Environment }
+    if ($VirtualMachineResourceTags) { $configArgs += '--addvirtualmachineresourcetags', '--virtualmachineresourcetags', $VirtualMachineResourceTags }
 	if ($ProjectName) { $configArgs += '--projectname', $ProjectName }
 
     if ( $Replace ) { $configArgs += '--replace' }


### PR DESCRIPTION
Add environment and virtual machine resource tags parameters to Install-VSTSAgent and the VSTSAgent DSC module. This allows installing an agent as an environment virtual machine resource.

Resolves #32 

My powershell is very weak, but the change doesn't seem that difficult so hopefully I didn't screw anything up.