### PR TITLE
Add support for installing pipelines-agent binaries, but default to installing vsts-agent binaries

### DIFF
--- a/VSTSAgent/VSTSAgent.psm1
+++ b/VSTSAgent/VSTSAgent.psm1
@@ -313,7 +313,17 @@ function Install-VSTSAgent {
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
     }
 
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($destPath, $agentFolder, $true)
+    if (Test-Path -Path $agentFolder -PathType Container) {
+        if ($PSCmdlet.ShouldProcess($agentFolder, "Overwriting with content of $($destPath)")) {
+            [System.IO.Compression.ZipFile]::ExtractToDirectory($destPath, $agentFolder, $true)
+        }
+        else {
+            throw "$($agentFolder) already exists."
+        }
+    }
+    else {
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($destPath, $agentFolder)
+    }
 
     $configPath = [io.path]::combine($agentFolder, 'config.cmd')
     $configPath = Get-ChildItem $configPath -ErrorAction SilentlyContinue


### PR DESCRIPTION
binaries come in vsts-agent and pipelines-agent flavors. Former has a dependency on Node6 while latter supports Node10 or later. For users of this module who want to switch to modern tasks that can run on Node10 or newer, they can set AgentType parameter to `pipelines-agent` and it will pick the matching resource in Find-VstsAgent.

Resolves #42 